### PR TITLE
Version correctly referencing less.js

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<link rel="stylesheet" type="text/css" href="less/metro.less" />
+		<link rel="stylesheet/less" type="text/css" href="less/metro.less" />
 		<style>
-			body { width: 800px; margin-left:auto; margin-right:auto; }
+			body { width: 800px; margin: 0 auto; }
 		</style>
 		<script src="scripts/less-1.2.1.min.js" type="text/javascript"></script>
 	</head>

--- a/less/fonts.less
+++ b/less/fonts.less
@@ -1,16 +1,24 @@
+@fonts: "Segoe UI", "Segoe WP", "Helvetica Neue", Roboto, sans-serif;
+
 body {
-	font-family: "Segoe UI", "Segoe WP", "Helvetica Neue", Roboto, sans-serif;
+	font-family: @fonts;
 }
 
-h1,h2,h3,h4,h5,h6 
+h1, h2, h3, h4, h5, h6 
 {
-	font-weight: 100;
 	color: @accent;
+	font-weight: 100;
 	line-height: 1em;
 	text-transform: lowercase;
 }
-h1 { font-size: 4em;}
-h2 { font-size: 3em; }
+
+h1, h2 {
+	font-family: "Segoe UI Light", @fonts;
+}
+
+h1 { font-size: 3.8em; }
+h2 { font-size: 2em; }
+
 h4 {
 	font-weight: normal;
 	text-transform: uppercase;


### PR DESCRIPTION
Also, h1 and h2 headings now explicitly use the "Segoe UI Light" font (Chrome i.e. does not use "Segoe UI Light" when using "Segoe UI" and "font-size: 100;")
