### PR TITLE
Reference "jquery.metro.js" correctly

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -7,7 +7,7 @@
 		</style>
 		<script src="scripts/less-1.2.1.min.js" type="text/javascript"></script>
 		<script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
-		<script type="text/javascript" src="js/jquery.metro.js"></script>
+		<script type="text/javascript" src="scripts/jquery.metro.js"></script>
 	</head>
 	<body>
 		<h1 class="accent">LARGE heading text</h1>


### PR DESCRIPTION
This version now references "jquery.metro.js" correctly.
