### PR TITLE
Upgrade jQuery to 1.7.2. Use path from Microsoft CDN.

### DIFF
--- a/demos/fonts/index.html
+++ b/demos/fonts/index.html
@@ -6,7 +6,7 @@
 			body { width: 800px; margin: 0 auto; }
 		</style>
 		<script src="/scripts/less-1.2.1.min.js" type="text/javascript"></script>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js"></script>
 		<script type="text/javascript" src="/scripts/jquery.metro.js"></script>
 	</head>
 	<body>

--- a/demos/pivot/index.html
+++ b/demos/pivot/index.html
@@ -6,7 +6,7 @@
 			body { width: 800px; margin: 0 auto; }
 		</style>
 		<script src="/scripts/less-1.2.1.min.js" type="text/javascript"></script>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js"></script>
 		<script type="text/javascript" src="/scripts/jquery.metro.js"></script>
 	</head>
 	<body>
@@ -27,7 +27,7 @@
 
 				To get started, reference the two JS files 
 
-<pre>&lt;script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"&gt;&lt;/script&gt;
+<pre>&lt;script type="text/javascript" src="/ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js"&gt;&lt;/script&gt;
 &lt;script type="text/javascript" src="/scripts/jquery.metro.js"&gt;&lt;/script&gt;</pre>
 				
 				Then define the the DOM for the tabs. The <code>metro-pivot</code> represents the container for the control, and the <code>pivot-item</code> represents each item in the collection.

--- a/demos/slides/index.html
+++ b/demos/slides/index.html
@@ -92,7 +92,7 @@
     <link rel="stylesheet/less" type="text/css" href="/less/metro.less" />
 
     <script src="/scripts/less-1.2.1.min.js" type="text/javascript"></script>
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js"></script>
     <script type="text/javascript" src="/scripts/jquery.metro.js"></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 			body { width: 900px; margin: 0 auto; }
 		</style>
 		<script src="/scripts/less-1.2.1.min.js" type="text/javascript"></script>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-1.5.1.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js"></script>
 		<script type="text/javascript" src="/scripts/jquery.metro.js"></script>
 		<script type="text/javascript" src="/scripts/tilt.js"></script>
 	</head>

--- a/node/metro.js
+++ b/node/metro.js
@@ -85,7 +85,7 @@ var jadeLayout = [
   , '    link(rel=\'stylesheet\', href=\'/css/metro.css\')'
   , '    style'
   , '      body { width: 800px; margin: 0 auto; }'
-  , '    script(type=\'text/javascript\', src=\'http://code.jquery.com/jquery-1.5.1.min.js\')'
+  , '    script(type=\'text/javascript\', src=\'//ajax.aspnetcdn.com/ajax/jquery/jquery-1.7.2.min.js\')'
   , '    script(type=\'text/javascript\', src=\'/js/jquery.metro.js\')'
   , '  body.whitebg.blue!= body'
 ].join(eol);


### PR DESCRIPTION
- Upgrade current jQuery (1.5.1) to jQuery 1.7.2. 
- Updated path to use Microsoft CDN
- Applied change to the Jade template which gets used when generating new projects off of Metro.css (metro.js)
- Changed path to start with "//" to be protocol agnostic (http/https)
